### PR TITLE
Update production URL

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico"/>
-    <meta name="viewport" content="width=device-width"/>
 
     <title>Firefox Test Pilot - Contribute</title>
     <link rel="canonical" href="https://contribute.testpilot.firefox.com/"/>

--- a/public/index.html
+++ b/public/index.html
@@ -7,13 +7,13 @@
     <meta name="viewport" content="width=device-width"/>
 
     <title>Firefox Test Pilot - Contribute</title>
-    <link rel="canonical" href="https://testpilot-contribute.herokuapp.com/"/>
+    <link rel="canonical" href="https://contribute.testpilot.firefox.com/"/>
     <meta name="description" content="Start contributing to open source software and help build Firefox with Test Pilot."/>
 
     <meta property="og:title" content="Firefox Test Pilot - Contribute"/>
     <meta property="og:description" content="Start contributing to open source software and help build Firefox with Test Pilot."/>
     <meta property="og:image" content="https://testpilot.firefox.com/static/images/thumbnail-facebook.png"/>
-    <meta property="og:url" content="https://testpilot-contribute.herokuapp.com"/>
+    <meta property="og:url" content="https://contribute.testpilot.firefox.com"/>
 
     <meta name="twitter:title" content="Firefox Test Pilot- Contribute"/>
     <meta name="twitter:description" content="Start contributing to open source software and help build Firefox with Test Pilot."/>


### PR DESCRIPTION
Somebody with higher permissions than I will also need to change the URL at the top of the GitHub repo.

<img width="895" alt="chuckharmston_testpilot-contribute__a_minisite_aggregating_open_bugs_suitable_for_first-time_contributors_across_test_pilot_s_various_projects_and_repositories_" src="https://user-images.githubusercontent.com/557895/29149065-7773b3de-7d26-11e7-8b0a-704e6e1e82fa.png">
